### PR TITLE
Remove placeholder posters for seamless video transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     </head>
 <body>
     <div id="game-container">
-        <video id="main-video-player" playsinline poster="https://placehold.co/960x540/000000/FFFFFF?text=Loading+Video...">
+        <video id="main-video-player" playsinline>
             Your browser does not support the video tag.
         </video>
         <div id="hotspot-container">

--- a/script.js
+++ b/script.js
@@ -202,7 +202,8 @@ function loadVideo(videoKey, autoplay = true) {
     }
     
     videoPlayer.src = data.src;
-    videoPlayer.poster = data.poster || `https://placehold.co/960x540/111/FFF?text=${videoKey.replace(/_/g, '+')}`;
+    // Remove placeholder posters between videos for a seamless transition
+    videoPlayer.removeAttribute('poster');
     // messageArea.textContent = `Loading: ${videoKey}`; // Keep this minimal to avoid overwriting important messages too quickly
     
     clearHotspots();


### PR DESCRIPTION
## Summary
- eliminate placeholder poster from the main video element
- do not set any poster when changing videos for smooth transitions

## Testing
- `npm test` *(fails: could not read package.json)*