### PR TITLE
Add looping background video on menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,10 +30,16 @@
     </div>
 
     <!-- Main Menu Screen -->
-    <div id="main-menu-screen" class="hidden menu-screen">
-        <button id="menu-play" class="menu-button">Play</button>
-        <button id="menu-character-select" class="menu-button">Character Select</button>
-        <button id="menu-settings" class="menu-button">Settings</button>
+    <div id="main-menu-screen" class="hidden menu-screen relative">
+        <video id="main-menu-background" autoplay loop muted>
+            <source src="videos/main_menu.mp4" type="video/mp4" />
+        </video>
+        <div class="overlay"></div>
+        <div class="relative z-20 flex flex-col items-center">
+            <button id="menu-play" class="menu-button">Play</button>
+            <button id="menu-character-select" class="menu-button">Character Select</button>
+            <button id="menu-settings" class="menu-button">Settings</button>
+        </div>
     </div>
 
     <div id="character-select-screen" class="hidden relative flex size-full min-h-screen flex-col overflow-hidden">

--- a/script.js
+++ b/script.js
@@ -197,12 +197,21 @@ function showMainMenuScreen() {
     if (mainMenuScreen) {
         mainMenuScreen.classList.remove('hidden');
         overlayPlayButton.classList.add('hidden');
+        const menuVideo = document.getElementById('main-menu-background');
+        if (menuVideo) {
+            menuVideo.play().catch(() => {});
+        }
     }
 }
 
 function hideMainMenuScreen() {
     if (mainMenuScreen) {
         mainMenuScreen.classList.add('hidden');
+        const menuVideo = document.getElementById('main-menu-background');
+        if (menuVideo) {
+            menuVideo.pause();
+            menuVideo.currentTime = 0;
+        }
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -170,8 +170,26 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background: rgba(0,0,0,0.8);
+  overflow: hidden;
   z-index: 20;
+}
+.menu-screen .overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  z-index: 10;
+}
+#main-menu-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 0;
 }
 .menu-screen.hidden { display: none; }
 .menu-button {


### PR DESCRIPTION
## Summary
- embed a looping `main_menu.mp4` video in the main menu screen
- style the menu to show the background video and dark overlay
- start and stop the menu video when showing or hiding the menu screen

## Testing
- `git status --short`