### PR TITLE
Fix main menu initialization timing

### DIFF
--- a/script.js
+++ b/script.js
@@ -528,7 +528,7 @@ overlayPlayButton.addEventListener('click', () => {
     videoPlayer.play().catch(handlePlayError);
 });
 
-window.addEventListener('load', () => {
+document.addEventListener('DOMContentLoaded', () => {
     resetGameState();
     showMainMenuScreen();
     messageArea.textContent = "Welcome to Penalty King!";


### PR DESCRIPTION
## Summary
- show the main menu once the DOM is ready rather than waiting for all assets

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`