### PR TITLE
Fix main menu video playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
     <!-- Main Menu Screen -->
     <div id="main-menu-screen" class="hidden menu-screen relative">
-        <video id="main-menu-background" autoplay loop muted>
+        <video id="main-menu-background" autoplay loop muted playsinline preload="auto">
             <source src="videos/main_menu.mp4" type="video/mp4" />
         </video>
         <div class="overlay"></div>

--- a/script.js
+++ b/script.js
@@ -199,6 +199,7 @@ function showMainMenuScreen() {
         overlayPlayButton.classList.add('hidden');
         const menuVideo = document.getElementById('main-menu-background');
         if (menuVideo) {
+            menuVideo.load();
             menuVideo.play().catch(() => {});
         }
     }


### PR DESCRIPTION
## Summary
- ensure the menu video loads inline
- trigger a load before playing the menu video

## Testing
- `npm test` *(fails: package.json missing)*